### PR TITLE
Avoid js path error

### DIFF
--- a/assets/javascripts/mipise-asset/app.js
+++ b/assets/javascripts/mipise-asset/app.js
@@ -1,5 +1,5 @@
-import { loadCustomInputMasks } from "./utils/input_masks.js";
-import './elements/sidebar.js'
+import { loadCustomInputMasks } from "./mipise-asset/utils/input_masks.js";
+import './mipise-asset/elements/sidebar.js'
 
 document.addEventListener('DOMContentLoaded', function () {
   // Popper.js


### PR DESCRIPTION
We have js error on staging as:
GET https://normacapital.mipise-staging.fr/assets/utils/input_masks.js net::ERR_ABORTED 404 (Not Found). 
The path should be :
https://normacapital.mipise-staging.fr/assets/mipise-asset/utils/input_masks.js
I added `mipise-asset` to the path to be able to find right js file