### PR TITLE
Modified Radio buttons

### DIFF
--- a/src/components/Inputs/Radios/CustomRadio.tsx
+++ b/src/components/Inputs/Radios/CustomRadio.tsx
@@ -19,6 +19,11 @@ const CustomRadio: React.FC<CustomRadioProps> = ({
   classes = "",
   disabled = false,
 }) => {
+  const inputName = formatName(objectName, attribute);
+
+  // Find selected item (important for fallback submission)
+  const selectedItem = items.find((i) => i.selected);
+
   return (
     <div
       className={`form-group ${formatId(objectName, attribute)} radio_buttons ${classes}`}
@@ -27,22 +32,29 @@ const CustomRadio: React.FC<CustomRadioProps> = ({
         {legend}
       </legend>
 
-      <input
-        type="hidden"
-        name={formatName(objectName, attribute)}
-        autoComplete="off"
-      />
-      {items.map((i, index) => {
-        return (
-          <CustomRadioItem
-            key={index}
-            attribute={attribute}
-            objectName={objectName}
-            disabled={disabled}
-            {...i}
-          />
-        );
-      })}
+      {disabled ? (
+        <input
+          type="hidden"
+          name={inputName}
+          value={selectedItem?.value ?? ""}
+        />
+      ) : (
+        <input
+          type="hidden"
+          name={inputName}
+          autoComplete="off"
+        />
+      )}
+
+      {items.map((i, index) => (
+        <CustomRadioItem
+          key={index}
+          attribute={attribute}
+          objectName={objectName}
+          disabled={disabled}
+          {...i}
+        />
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
When the `CustomRadio` component was used with the `disabled` prop, the selected value was not submitted to the backend because disabled inputs are excluded from form submissions by default in HTML. This caused missing parameters (e.g. `beneficiary[sepa]`) in the controller. To fix this, the component now injects a hidden input containing the selected value when it is disabled, ensuring the data is always sent while preserving the non-interactive UI state. This makes the component behavior consistent and prevents silent data loss without requiring changes in individual views.
